### PR TITLE
Run yarn install in the current workdir so all bins are available to …

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,14 +1,13 @@
 FROM node:12-alpine
 
-WORKDIR /opt
+ENV INSTALL_PATH /var/task
+
+WORKDIR $INSTALL_PATH
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --ignore-optional \
-  && yarn global add serverless
-
-ENV PATH=/opt/node_modules/.bin:${PATH}
-
-WORKDIR /var/task
+RUN yarn install --no-cache --frozen-lockfile --ignore-optional && \
+    yarn autoclean --force && \
+    yarn global add serverless
 
 COPY . .
 


### PR DESCRIPTION
…user

@laurxnemeth this should do it. i just simplified the build so that yarn install is run in the same working directory that the tests are run. there is no need for acrobatics since this builds and run as the root user