### PR TITLE
Don't exclude node_modules, we need them

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -15,10 +15,7 @@ package:
     - handler.js
     - lib/**/*
   exclude:
-    - node_modules/**/*
-    - package.json
-    - yarn.lock
-    - Dockerfile
+    - Dockerfile*
     - docker-compose.yml
     - spec/*
     - .env


### PR DESCRIPTION
@laurxnemeth @ericgriffis This was my fault, but I think I copied it from somewhere (copy/paste strikes again). We don't want to actively exclude node_modules from the package because that's where the dependencies are.

We probably want to limit the size of the package by only sending the packages we need (i.e. axios), see https://www.serverless.com/framework/docs/providers/aws/guide/packaging/.

Or alternatively we could only build production packages during the CD process. The former option might be the easier one.